### PR TITLE
Potential fix for code scanning alert no. 6: Storage of sensitive information in build artifact

### DIFF
--- a/app/app-info.ts
+++ b/app/app-info.ts
@@ -32,3 +32,11 @@ export function getReplacements() {
     'process.env.TEST_ENV': s(process.env.TEST_ENV),
   }
 }
+
+// Return a replacements object with sensitive values omitted for public bundles
+export function getSafeReplacements() {
+  const all = getReplacements()
+  // Make a shallow copy and delete sensitive keys
+  const { __OAUTH_CLIENT_ID__, __OAUTH_SECRET__, ...safe } = all
+  return safe
+}

--- a/app/webpack.common.ts
+++ b/app/webpack.common.ts
@@ -8,6 +8,7 @@ export const externals = ['7zip']
 
 const outputDir = 'out'
 export const replacements = getReplacements()
+export const safeReplacements = require('./app-info').getSafeReplacements()
 
 const commonConfig: webpack.Configuration = {
   optimization: {
@@ -160,7 +161,7 @@ export const highlighter = merge({}, commonConfig, {
   target: 'webworker',
   plugins: [
     new webpack.DefinePlugin(
-      Object.assign({}, replacements, {
+      Object.assign({}, safeReplacements, {
         __PROCESS_KIND__: JSON.stringify('highlighter'),
       })
     ),


### PR DESCRIPTION
Potential fix for [https://github.com/start-export-MA/ubiquitous-waffle/security/code-scanning/6](https://github.com/start-export-MA/ubiquitous-waffle/security/code-scanning/6)

**General approach:**  
We should ensure that sensitive secrets (like `OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET`) are never placed in a Webpack build intended for public distribution. Only non-sensitive, public, or otherwise intentionally exposed variables should be provided to the client bundle. 

**Specific fix:**  
- In `app/app-info.ts`, the `getReplacements` function currently always includes `__OAUTH_CLIENT_ID__` and `__OAUTH_SECRET__` in its return value, sometimes from environment variables, sometimes from hardcoded secrets. Instead, these should only be included for server-side bundles or "safe" development builds.  
- For Webpack client/webworker bundles like "highlighter", remove these secrets from the `replacements` object that is fed to the plugin.
- This can be accomplished by creating a new `getSafeReplacements()` function in `app/app-info.ts` that strips out sensitive properties, and use this safe version in `webpack.common.ts` when assembling the configuration for client/public builds like "highlighter".

**Implementation steps:**  
- In `app/app-info.ts`, add a function like `getSafeReplacements` which returns the replacements object minus the sensitive keys (`__OAUTH_CLIENT_ID__`, `__OAUTH_SECRET__`).  
- In `app/webpack.common.ts`, use this safe function for public bundles (like "highlighter").  
- Do not modify any other functionality or unrelated configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
