### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       RELEASE_CHANNEL: ${{ inputs.environment }}
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/start-export-MA/ubiquitous-waffle/security/code-scanning/1](https://github.com/start-export-MA/ubiquitous-waffle/security/code-scanning/1)

The most appropriate fix is to add a `permissions` block to the `lint` job, granting only the minimal access required. For typical lint steps (checkout, setup-node, install, linting, validation commands), only the ability to read the repo contents is needed. Therefore, add  
```yaml  
permissions:  
  contents: read  
```  
just after `runs-on: ubuntu-latest` in the `lint` job in `.github/workflows/ci.yml`.  
No further imports, definitions, or additional methods are needed. Only this addition is required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
