### PR TITLE
Potential fix for code scanning alert no. 5: Storage of sensitive information in build artifact

### DIFF
--- a/app/webpack.common.ts
+++ b/app/webpack.common.ts
@@ -115,7 +115,7 @@ export const cli = merge({}, commonConfig, {
   target: 'node',
   plugins: [
     new webpack.DefinePlugin(
-      Object.assign({}, replacements, {
+      Object.assign({}, safeReplacements, {
         __PROCESS_KIND__: JSON.stringify('cli'),
       })
     ),


### PR DESCRIPTION
Potential fix for [https://github.com/start-export-MA/ubiquitous-waffle/security/code-scanning/5](https://github.com/start-export-MA/ubiquitous-waffle/security/code-scanning/5)

To fix this issue, we need to ensure that **only safe, non-sensitive values** are injected into build artifacts via Webpack’s DefinePlugin. Specifically:
- Only use `safeReplacements` (returned by `getSafeReplacements()`) anywhere sensitive info should *not* be exposed, such as in renderer, crash, cli, and highlighter builds.
- For the main process build—which may require secrets for authentication—a security review must be performed, but often only the main build should receive secrets. If possible, this should also use `safeReplacements`.
- The concrete change: In `app/webpack.common.ts`, replace the usage of `replacements` with `safeReplacements` in the relevant Webpack config blocks (especially the CLI config, which is the source of the alert).
- No method definitions or custom logic needs to be implemented; simply swap the variable to use `safeReplacements`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
